### PR TITLE
Change lists method to pluck - lists method is removed in Laravel 5.3

### DIFF
--- a/src/DatabaseSettingStore.php
+++ b/src/DatabaseSettingStore.php
@@ -114,7 +114,7 @@ class DatabaseSettingStore extends SettingStore
 	protected function write(array $data)
 	{
 		$keys = $this->newQuery()
-			->pluck('key');
+			->pluck('key')->all();
 
 		$insertData = array_dot($data);
 		$updateData = array();

--- a/src/DatabaseSettingStore.php
+++ b/src/DatabaseSettingStore.php
@@ -61,11 +61,10 @@ class DatabaseSettingStore extends SettingStore
 		$this->table = $table;
 	}
 
-	/**
-	 * Set the query constraint.
-	 *
-	 * @param Closure $callback
-	 */
+    /**
+     * Set the query constraint.
+     * @param \Closure $callback
+     */
 	public function setConstraint(\Closure $callback)
 	{
 		$this->data = array();
@@ -115,7 +114,7 @@ class DatabaseSettingStore extends SettingStore
 	protected function write(array $data)
 	{
 		$keys = $this->newQuery()
-			->lists('key');
+			->pluck('key');
 
 		$insertData = array_dot($data);
 		$updateData = array();
@@ -149,7 +148,7 @@ class DatabaseSettingStore extends SettingStore
 	}
 
 	/**
-	 * Transforms settings data into an array ready to be insterted into the
+	 * Transforms settings data into an array ready to be inserted into the
 	 * database. Call array_dot on a multidimensional array before passing it
 	 * into this method!
 	 *

--- a/src/DatabaseSettingStore.php
+++ b/src/DatabaseSettingStore.php
@@ -115,10 +115,10 @@ class DatabaseSettingStore extends SettingStore
 	{
 		$keysQuery = $this->newQuery();
 
-		if (method_exists($keysQuery, 'lists')) {
-			$keys = $keysQuery->lists('key');
-		} else {
+		if (method_exists($keysQuery, 'pluck')) {
 			$keys = $keysQuery->pluck('key')->all();
+		} else {
+			$keys = $keysQuery->lists('key');
 		}
 
 		$insertData = array_dot($data);

--- a/src/DatabaseSettingStore.php
+++ b/src/DatabaseSettingStore.php
@@ -115,7 +115,7 @@ class DatabaseSettingStore extends SettingStore
 	{
 		$keysQuery = $this->newQuery();
 
-		if (method_exists($query, 'lists')) {
+		if (method_exists($keysQuery, 'lists')) {
 			$keys = $keysQuery->lists('key');
 		} else {
 			$keys = $keysQuery->pluck('key')->all();


### PR DESCRIPTION
Hi @anlutro ,
Lists method is removed in Laravel 5.3 so please review and merge my pull request.
When it is merged, this package can work properly on Laravel 5.3.
Thanks.