### PR TITLE
Added parameters in config file to set the key and value columns name

### DIFF
--- a/src/SettingsManager.php
+++ b/src/SettingsManager.php
@@ -30,10 +30,11 @@ class SettingsManager extends Manager
 	{
 		$connectionName = $this->getConfig('anlutro/l4-settings::connection');
 		$connection = $this->app['db']->connection($connectionName);
-		$key_column = $this->getConfig('anlutro/l4-settings::key_column_name');
-        $value_column = $this->getConfig('anlutro/l4-settings::value_column_name');
+		$table = $this->getConfig('anlutro/l4-settings::table');
+		$keyColumn = $this->getConfig('anlutro/l4-settings::keyColumn');
+		$valueColumn = $this->getConfig('anlutro/l4-settings::valueColumn');
 
-		return new DatabaseSettingStore($connection, $table, $key_column, $value_column);
+		return new DatabaseSettingStore($connection, $table, $keyColumn, $valueColumn);
 	}
 
 	public function createMemoryDriver()

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -17,6 +17,6 @@ return array(
 
 	// If you want to use custom column names in database store you could 
 	// set them in this configuration
-	'keyColumn' => 'setting_key',
-	'valueColumn' => 'setting_value'
+	'keyColumn' => 'key',
+	'valueColumn' => 'value'
 );

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -14,4 +14,9 @@ return array(
 	// If the database store is used, you can set which connection to use. if
 	// set to null, the default connection will be used.
 	'connection' => null,
+
+	// If you want to use custom column names in database store you could 
+	// set them in this configuration
+	'keyColumn' => 'setting_key',
+	'valueColumn' => 'setting_value'
 );

--- a/src/migrations/2015_08_25_172600_create_settings_table.php
+++ b/src/migrations/2015_08_25_172600_create_settings_table.php
@@ -11,12 +11,12 @@ class CreateSettingsTable extends Migration
 	{
 		if (version_compare(Application::VERSION, '5.0', '>=')) {
 			$this->tablename = Config::get('settings.table');
-			$this->key_column_name = Config::get('settings.key_column_name');
-            $this->value_column_name = Config::get('settings.value_column_name');
+			$this->keyColumn = Config::get('settings.keyColumn');
+			$this->valueColumn = Config::get('settings.valueColumn');
 		} else {
 			$this->tablename = Config::get('anlutro/l4-settings::table');
-			$this->key_column_name = Config::get('anlutro/l4-settings::key_column_name');
-            $this->value_column_name = Config::get('anlutro/l4-settings::value_column_name');
+			$this->keyColumn = Config::get('anlutro/l4-settings::keyColumn');
+			$this->valueColumn = Config::get('anlutro/l4-settings::valueColumn');
 		}
 	}
 
@@ -30,8 +30,8 @@ class CreateSettingsTable extends Migration
 		Schema::create($this->tablename, function(Blueprint $table)
 		{
 			$table->increments('id');
-			$table->string($this->key_column_name)->index();
-			$table->text($this->value_column_name);
+			$table->string($this->keyColumn)->index();
+			$table->text($this->valueColumn);
 		});
 	}
 


### PR DESCRIPTION
Added parameters in config file to set the key and value columns name. This parameters are used in migration when is created the table, and used in DatabaseSettingStore to persist and query the data using the setted column names.