### PR TITLE
Added load method

### DIFF
--- a/src/SettingStore.php
+++ b/src/SettingStore.php
@@ -106,6 +106,15 @@ abstract class SettingStore
 		$this->data = array();
 	}
 
+    /**
+     * Load the settings data.
+     */
+    public function load()
+    {
+        $this->data = $this->read();
+        $this->loaded = true;
+    }
+
 	/**
 	 * Get all settings data.
 	 *
@@ -141,8 +150,7 @@ abstract class SettingStore
 	protected function checkLoaded()
 	{
 		if (!$this->loaded) {
-			$this->data = $this->read();
-			$this->loaded = true;
+			$this->load();
 		}
 	}
 


### PR DESCRIPTION
This is useful when you want to get the data for different user_id during the runtime. Firstly `forgetAll` then `load` the data. Doesn't break the backward compatibility.