### PR TITLE
Integer timestamps support and filterColumns support

### DIFF
--- a/src/migrations/2015_08_25_172600_create_settings_table.php
+++ b/src/migrations/2015_08_25_172600_create_settings_table.php
@@ -32,6 +32,8 @@ class CreateSettingsTable extends Migration
 			$table->increments('id');
 			$table->string($this->keyColumn)->index();
 			$table->text($this->valueColumn);
+			$table->integer('created_at');
+			$table->integer('updated_at');
 		});
 	}
 


### PR DESCRIPTION
- Adds 2 columns `created_at` and `updated_at` timestamps in the table. The epoch values of time is stored in the database, hence, integers.
- Currently, `setExtraColumns` function not only sets the extra columns, but also adds a filter for each of the column while looking up the table. This PR separates out the 2 operations, with the functions `setExtraColumns` which can be used only to set the extra columns, and `setFilterColumns` which can be used to apply filters for a particular field while looking up in the table.