### PR TITLE
Adds date-time formatted timestamps

### DIFF
--- a/src/migrations/2015_08_25_172600_create_settings_table.php
+++ b/src/migrations/2015_08_25_172600_create_settings_table.php
@@ -32,6 +32,8 @@ class CreateSettingsTable extends Migration
 			$table->increments('id');
 			$table->string($this->keyColumn)->index();
 			$table->text($this->valueColumn);
+			$table->timestamp('created_at')->default(\DB::raw('CURRENT_TIMESTAMP'));
+			$table->timestamp('updated_at')->default(\DB::raw('CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP'));
 		});
 	}
 


### PR DESCRIPTION
- Adds 2 columns created_at and updated_at timestamps in the table. The values are stored in the database as timestamps, in the format `YYYY-MM-DD hh:mm:ss`.
- This PR implements the functionality of adding timestamps by adding `CURRENT_TIMESTAMP` and `CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP` in the table schema itself.