### PR TITLE
Add migration publishing, update config publishing and environmental variables

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Laravel 4 - Persistent Settings
- * 
+ *
  * @author   Andreas Lutro <anlutro@gmail.com>
  * @license  http://opensource.org/licenses/MIT
  * @package  l4-settings
@@ -36,7 +36,7 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
 					$app->make('anlutro\LaravelSettings\SettingStore')->save();
 				});
 			}
-			
+
 			/**
 			 * Construct the actual manager.
 			 */
@@ -58,23 +58,20 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
 	 */
 	public function boot()
 	{
-		if (version_compare(Application::VERSION, '5.3', '>=')) {
-			$this->loadMigrationsFrom(__DIR__.'/migrations');
+		$this->publishes([
+				__DIR__.'/config/config.php' => config_path('settings.php'),
+		], 'config');
+
+		$this->mergeConfigFrom(__DIR__.'/config/config.php', 'settings');
+
+		if (! class_exists('CreateSettingsTable')) {
+			$timestamp = date('Y_m_d_His', time());
+
 			$this->publishes([
-				__DIR__.'/config/config.php' => config_path('settings.php')
-			], 'config');
-		} else if (version_compare(Application::VERSION, '5.0', '>=')) {
-			$this->publishes([
-				__DIR__.'/config/config.php' => config_path('settings.php')
-			], 'config');
-			$this->publishes([
-				__DIR__.'/migrations' => database_path('migrations')
+				__DIR__.'/migrations/create_settings_table.php.stub' => database_path("/migrations/{$timestamp}_create_settings_table.php"),
 			], 'migrations');
-		} else {
-			$this->app['config']->package(
-				'anlutro/l4-settings', __DIR__ . '/config', 'anlutro/l4-settings'
-			);
 		}
+
 	}
 
 	/**

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -12,7 +12,7 @@ return [
 	| Supported: "json", "database"
 	|
 	*/
-	'store' => 'json',
+	'store' => env('SETTINGS_STORE', 'json'),
 
 	/*
 	|--------------------------------------------------------------------------
@@ -23,7 +23,7 @@ return [
 	| file path in JSON format. Use full path to file.
 	|
 	*/
-	'path' => storage_path().'/settings.json',
+	'path' => storage_path().env('SETTINGS_PATH', '/settings.json'),
 
 	/*
 	|--------------------------------------------------------------------------
@@ -35,11 +35,11 @@ return [
 	|
 	*/
 	// If set to null, the default connection will be used.
-	'connection' => null,
+	'connection' => env('SETTINGS_CONNECTION', null),
 	// Name of the table used.
-	'table' => 'settings',
-	// If you want to use custom column names in database store you could 
+	'table' => env('SETTINGS_TABLE', 'settings'),
+	// If you want to use custom column names in database store you could
 	// set them in this configuration
-	'keyColumn' => 'key',
-	'valueColumn' => 'value'
+	'keyColumn' => env('SETTINGS_KEY_COLUMN', 'key'),
+	'valueColumn' => env('SETTINGS_VALUE_COLUMN', 'value')
 ];

--- a/src/migrations/create_settings_table.php.stub
+++ b/src/migrations/create_settings_table.php.stub
@@ -9,15 +9,9 @@ class CreateSettingsTable extends Migration
 {
 	public function __construct()
 	{
-		if (version_compare(Application::VERSION, '5.0', '>=')) {
-			$this->tablename = Config::get('settings.table');
-			$this->keyColumn = Config::get('settings.keyColumn');
-			$this->valueColumn = Config::get('settings.valueColumn');
-		} else {
-			$this->tablename = Config::get('anlutro/l4-settings::table');
-			$this->keyColumn = Config::get('anlutro/l4-settings::keyColumn');
-			$this->valueColumn = Config::get('anlutro/l4-settings::valueColumn');
-		}
+		$this->tablename = Config::get('settings.table');
+		$this->keyColumn = Config::get('settings.keyColumn');
+		$this->valueColumn = Config::get('settings.valueColumn');
 	}
 
 	/**


### PR DESCRIPTION
Issue #81: Add migration publishing to service provider

* Change database migration to stub file
* Add migration publishing to ServiceProvider
* Update config publishing to publish and merge correctly

Fixes Issues #65 & #83: Have config file pull values from environmental variables

* Added `env()` helpers in `config.php` to allow easier changing of important settings in a per-environment basis