### PR TITLE
Running the built-in migration is optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ You can modify the path used on run-time using `Setting::setPath($path)`.
 
 #### Using Migration File
 
-If you use the database store you need to run `php artisan migrate --package=anlutro/l4-settings` (Laravel 4.x) or `php artisan migrate --path=vendor/anlutro/l4-settings/src/migrations` (Laravel 5.x) to generate the table.
+If you use the database store you need to run `php artisan migrate --package=anlutro/l4-settings` (Laravel 4.x) or `php artisan vendor:publish --provider="anlutro/l4-settings" --tag="migrations" && php artisan migrate` (Laravel 5.x) to generate the table.
 
 #### Example
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Despite the package name, this package works with Laravel 5.x!
 ## Installation - Laravel >= 5.5
 
 1. `composer require anlutro/l4-settings`
-2. Publish the config file by running `php artisan vendor:publish --provider="anlutro/l4-settings" --tag="config"`. The config file will give you control over which storage engine to use as well as some storage-specific settings.
+2. Publish the config file by running `php artisan vendor:publish --provider="anlutro\LaravelSettings\ServiceProvider" --tag="config"`. The config file will give you control over which storage engine to use as well as some storage-specific settings.
 
 ## Installation - Laravel < 5.5
 
@@ -57,7 +57,7 @@ You can modify the path used on run-time using `Setting::setPath($path)`.
 
 #### Using Migration File
 
-If you use the database store you need to run `php artisan migrate --package=anlutro/l4-settings` (Laravel 4.x) or `php artisan vendor:publish --provider="anlutro/l4-settings" --tag="migrations" && php artisan migrate` (Laravel 5.x) to generate the table.
+If you use the database store you need to run `php artisan migrate --package=anlutro/l4-settings` (Laravel 4.x) or `php artisan vendor:publish --provider="anlutro\LaravelSettings\ServiceProvider" --tag="migrations" && php artisan migrate` (Laravel 5.x) to generate the table.
 
 #### Example
 

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -58,17 +58,12 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
 	 */
 	public function boot()
 	{
-		if (version_compare(Application::VERSION, '5.3', '>=')) {
-			$this->loadMigrationsFrom(__DIR__.'/migrations');
-			$this->publishes([
-				__DIR__.'/config/config.php' => config_path('settings.php')
-			], 'config');
-		} else if (version_compare(Application::VERSION, '5.0', '>=')) {
+		if (version_compare(Application::VERSION, '5.0', '>=')) {
 			$this->publishes([
 				__DIR__.'/config/config.php' => config_path('settings.php')
 			], 'config');
 			$this->publishes([
-				__DIR__.'/migrations' => database_path('migrations')
+				__DIR__.'/migrations/2015_08_25_172600_create_settings_table.php' => database_path('migrations/'.date('Y_m_d_His').'_create_settings_table.php')
 			], 'migrations');
 		} else {
 			$this->app['config']->package(


### PR DESCRIPTION
Before, the built-in migration run when you run `php artisan migrate` in Laravel ≥ 5.3 regardless, you couldn't even change the migration. Now you can install the migration to the `database/migrations` directory if you need it by running `php artisan vendor:publish --provider="anlutro\LaravelSettings\ServiceProvider" --tag="migrations"` and change the migration.

Resolves #91 and #81.

Also I've fixed the `php artisan vendor:publish` command syntax in the readme (in Laravel 5.* you need to specify the service class name, not the package name).