### PR TITLE
Add a setting() helper to act as an alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,9 @@
         "illuminate/filesystem": ">=4.1 <6.0"
     },
     "autoload": {
+        "files": [
+            "src/helpers.php"
+        ],
         "psr-4": {
             "anlutro\\LaravelSettings\\": "src/"
         }

--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,7 @@
     "require-dev": {
         "phpunit/phpunit": ">=4.8, <6",
         "mockery/mockery": "0.9.*",
-        "illuminate/database": ">=4.1 <6.0",
-        "illuminate/filesystem": ">=4.1 <6.0"
+        "laravel/framework": ">=4.1 <6.0"
     },
     "autoload": {
         "files": [

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -48,6 +48,8 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
 			return $app->make('anlutro\LaravelSettings\SettingsManager')->driver();
 		});
 
+		$this->app->alias('anlutro\LaravelSettings\SettingStore', 'setting');
+
 		if (version_compare(Application::VERSION, '5.0', '>=')) {
 			$this->mergeConfigFrom(__DIR__ . '/config/config.php', 'settings');
 		}

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -1,0 +1,16 @@
+<?php
+
+if (! function_exists('setting')) {
+    function setting($key = null, $default = null)
+    {
+        if (is_null($key)) {
+            return app('setting');
+        }
+
+        if (!is_null($default)) {
+            return app('setting')->set($key, $default);
+        }
+
+        return app('setting')->get($key, $default);
+    }
+}

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -7,8 +7,8 @@ if (! function_exists('setting')) {
             return app('setting');
         }
 
-        if (!is_null($default)) {
-            return app('setting')->set($key, $default);
+        if (is_array($key)) {
+            return app('setting')->set($key);
         }
 
         return app('setting')->get($key, $default);

--- a/tests/unit/HelperTest.php
+++ b/tests/unit/HelperTest.php
@@ -53,14 +53,3 @@ class HelperTest extends PHPUnit_Framework_TestCase
 		setting(['foo', 'bar']);
 	}
 }
-
-if (!function_exists('app')) {
-	function app($abstract = null, array $parameters = [])
-    {
-        if (is_null($abstract)) {
-            return Container::getInstance();
-        }
-
-        return Container::getInstance()->make($abstract, $parameters);
-    }
-}

--- a/tests/unit/HelperTest.php
+++ b/tests/unit/HelperTest.php
@@ -1,9 +1,21 @@
 <?php
 
 use Mockery as m;
+use Illuminate\Container\Container;
 
 class HelperTest extends PHPUnit_Framework_TestCase
 {
+	public function setUp()
+	{
+		parent::setUp();
+
+		$store = m::mock(anlutro\LaravelSettings\SettingStore::class);
+
+		Container::getInstance()->bind('setting', function() use ($store) {
+			return $store;
+		});
+	}
+
 	/** @test */
 	public function helper_without_parameters_returns_store() 
 	{
@@ -13,24 +25,30 @@ class HelperTest extends PHPUnit_Framework_TestCase
 	/** @test */
 	public function single_parameter_get_a_key_from_store() 
 	{
-		app()->shouldReceive('get')->with('foo', null)->once();
+		app('setting')->shouldReceive('get')->with('foo', null)->once();
 
 		setting('foo');
 	}
 
-
-	/** @test */
-	public function two_parameters_set_to_store() 
+	public function two_parameters_return_a_default_value()
 	{
-		app()->shouldReceive('set')->with('foo', 'bar')->once();
+		app('setting')->shouldReceive('get')->with('foo', 'bar')->once();
 
 		setting('foo', 'bar');
 	}
+
+
+	/** @test */
+	public function array_parameter_call_set_method_into_store() 
+	{
+		app('setting')->shouldReceive('set')->with(['foo', 'bar'])->once();
+
+		setting(['foo', 'bar']);
+	}
 }
 
-$containerInstance = m::mock('anlutro\LaravelSettings\SettingStore');
-
-function app() {
-	global $containerInstance;
-	return $containerInstance;
+if (!function_exists('app')) {
+	function app($var) {
+		return Container::getInstance()->make($var);
+	}
 }

--- a/tests/unit/HelperTest.php
+++ b/tests/unit/HelperTest.php
@@ -16,6 +16,8 @@ class HelperTest extends PHPUnit_Framework_TestCase
 		    return;
 		}
 
+		Container::setInstance(new Container);
+
 		$store = m::mock('anlutro\LaravelSettings\SettingStore');
 
 		app()->bind('setting', function() use ($store) {

--- a/tests/unit/HelperTest.php
+++ b/tests/unit/HelperTest.php
@@ -9,7 +9,7 @@ class HelperTest extends PHPUnit_Framework_TestCase
 	{
 		parent::setUp();
 
-		$store = m::mock(anlutro\LaravelSettings\SettingStore::class);
+		$store = m::mock('anlutro\LaravelSettings\SettingStore');
 
 		Container::getInstance()->bind('setting', function() use ($store) {
 			return $store;

--- a/tests/unit/HelperTest.php
+++ b/tests/unit/HelperTest.php
@@ -13,7 +13,7 @@ class HelperTest extends PHPUnit_Framework_TestCase
 	/** @test */
 	public function single_parameter_get_a_key_from_store() 
 	{
-		app()->shouldReceive('get')->with('foo', null);
+		app()->shouldReceive('get')->with('foo', null)->once();
 
 		setting('foo');
 	}
@@ -22,7 +22,7 @@ class HelperTest extends PHPUnit_Framework_TestCase
 	/** @test */
 	public function two_parameters_set_to_store() 
 	{
-		app()->shouldReceive('set')->with('foo', 'bar');
+		app()->shouldReceive('set')->with('foo', 'bar')->once();
 
 		setting('foo', 'bar');
 	}

--- a/tests/unit/HelperTest.php
+++ b/tests/unit/HelperTest.php
@@ -5,13 +5,20 @@ use Illuminate\Container\Container;
 
 class HelperTest extends PHPUnit_Framework_TestCase
 {
+	public static $functions;
+
 	public function setUp()
 	{
-		parent::setUp();
+		self::$functions = m::mock();
+
+		if (version_compare(\Illuminate\Foundation\Application::VERSION, '5.0', '<')) {
+		    $this->markTestSkipped('Laravel 5 feature.');
+		    return;
+		}
 
 		$store = m::mock('anlutro\LaravelSettings\SettingStore');
 
-		Container::getInstance()->bind('setting', function() use ($store) {
+		app()->bind('setting', function() use ($store) {
 			return $store;
 		});
 	}
@@ -48,7 +55,12 @@ class HelperTest extends PHPUnit_Framework_TestCase
 }
 
 if (!function_exists('app')) {
-	function app($var) {
-		return Container::getInstance()->make($var);
-	}
+	function app($abstract = null, array $parameters = [])
+    {
+        if (is_null($abstract)) {
+            return Container::getInstance();
+        }
+
+        return Container::getInstance()->make($abstract, $parameters);
+    }
 }

--- a/tests/unit/HelperTest.php
+++ b/tests/unit/HelperTest.php
@@ -1,0 +1,36 @@
+<?php
+
+use Mockery as m;
+
+class HelperTest extends PHPUnit_Framework_TestCase
+{
+	/** @test */
+	public function helper_without_parameters_returns_store() 
+	{
+		$this->assertInstanceOf('anlutro\LaravelSettings\SettingStore', setting());
+	}
+
+	/** @test */
+	public function single_parameter_get_a_key_from_store() 
+	{
+		app()->shouldReceive('get')->with('foo', null);
+
+		setting('foo');
+	}
+
+
+	/** @test */
+	public function two_parameters_set_to_store() 
+	{
+		app()->shouldReceive('set')->with('foo', 'bar');
+
+		setting('foo', 'bar');
+	}
+}
+
+$containerInstance = m::mock('anlutro\LaravelSettings\SettingStore');
+
+function app() {
+	global $containerInstance;
+	return $containerInstance;
+}


### PR DESCRIPTION
This PR will the same access to the settings store as Laravel does with `config()` helper:

- `setting()` will return the store instance.
- `setting($key)` would be an alias for Setting::get($key)
- `setting([$key => $value])` would be an alias for Setting::set([$key => $value])