### PR TITLE
Added alias for resolution

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -84,6 +84,7 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
 		return array(
 			'anlutro\LaravelSettings\SettingsManager',
 			'anlutro\LaravelSettings\SettingStore',
+			'setting'
 		);
 	}
 }


### PR DESCRIPTION
This alias needs to be added to the `provides()` method. Otherwise it does not resolve via app('setting'), sorry about that.