### PR TITLE
Making settings helper return the store

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -3,14 +3,14 @@
 if (! function_exists('setting')) {
     function setting($key = null, $default = null)
     {
-        if (is_null($key)) {
-            return app('setting');
-        }
+        $setting = app('setting');
 
         if (is_array($key)) {
-            return app('setting')->set($key);
+            $setting->set($key);
+        } elseif (! is_null($key)) {
+            return $setting->get($key, $default);
         }
 
-        return app('setting')->get($key, $default);
+        return $setting;
     }
 }


### PR DESCRIPTION
Small refactor. It will work the same but it will always return the Store instance if its not performing a `get` action. This way we will be able to chain like this:

```php
setting(['key' => 'value'])->save();
```