### PR TITLE
add ability to load default values from config file 'defaults' array…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0",
+        "php": ">=5.4.0",
         "illuminate/support": ">=4.1 <6.0"
     },
     "suggest": {

--- a/src/SettingStore.php
+++ b/src/SettingStore.php
@@ -9,8 +9,11 @@
 
 namespace anlutro\LaravelSettings;
 
+use \Illuminate\Support\Facades\Config;
+
 abstract class SettingStore
 {
+    use Config;
 	/**
 	 * The settings data.
 	 *
@@ -42,6 +45,10 @@ abstract class SettingStore
 	 */
 	public function get($key, $default = null)
 	{
+        if ($default === NULL) {
+            $default = Config::get('settings.defaults.'.$key);
+        }
+        
 		$this->load();
 
 		return ArrayUtil::get($this->data, $key, $default);

--- a/src/SettingStore.php
+++ b/src/SettingStore.php
@@ -13,7 +13,6 @@ use \Illuminate\Support\Facades\Config;
 
 abstract class SettingStore
 {
-    use Config;
 	/**
 	 * The settings data.
 	 *

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -41,5 +41,19 @@ return [
 	// If you want to use custom column names in database store you could 
 	// set them in this configuration
 	'keyColumn' => 'key',
-	'valueColumn' => 'value'
+	'valueColumn' => 'value',
+    
+    /*
+    |--------------------------------------------------------------------------
+    | Default Settings
+    |--------------------------------------------------------------------------
+    |
+    | Define all default settings that will be used before any settings are set,
+    | this avoids all settings being set to false to begin with and avoids
+    | hardcoding the same defaults in all 'Settings::get()' calls
+    |
+    */
+    'defaults' => [
+        'foo' => 'bar',
+    ]
 ];


### PR DESCRIPTION
… that will be used before any settings are set, this avoids all settings being set to false to begin with and avoids hardcoding the same defaults in all 'Settings::get()' calls, raises minimum php version to 5.4