### PR TITLE
Travis.yml: Include PHP 7.2 for Laravel 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ env:
   - COMPOSER_REQS="laravel/framework:5.1.*"
   - COMPOSER_REQS="laravel/framework:5.5.*"
   - COMPOSER_REQS="laravel/framework:>=5.7"
-  - COMPOSER_REQS="laravel/framework:>=6.*"
+  - COMPOSER_REQS="laravel/framework:>=6.0"
 
 matrix:
   exclude:
@@ -33,7 +33,7 @@ matrix:
       
   include: 
     - php: 7.2
-      env: COMPOSER_REQS="laravel/framework:>=6.*"
+      env: COMPOSER_REQS="laravel/framework:>=6.0"
 
 install:
   - composer require --no-update $COMPOSER_REQS

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ env:
   - COMPOSER_REQS="laravel/framework:5.1.*"
   - COMPOSER_REQS="laravel/framework:5.5.*"
   - COMPOSER_REQS="laravel/framework:>=5.7"
+  - COMPOSER_REQS="laravel/framework:>=6.*"
 
 matrix:
   exclude:
@@ -29,6 +30,10 @@ matrix:
       env: COMPOSER_REQS="laravel/framework:5.5.*"
     - php: 5.6
       env: COMPOSER_REQS="laravel/framework:>=5.7"
+      
+  include: 
+    - php: 7.2
+      env: COMPOSER_REQS="laravel/framework:>=6.*"
 
 install:
   - composer require --no-update $COMPOSER_REQS


### PR DESCRIPTION
Included PHP v. 7.2 for Laravel 6 on the Travis configuration files, since Laravel 6 support PHP version >= 7.2