### PR TITLE
Override configs and Blade directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,24 @@ setting()->set('foo', 'bar');
 setting(['foo' => 'bar'])->save();
 ```
 
+### Blade Directive
+
+You can get the settings directly in your blade templates using the helper method or the blade directive like `@setting('foo')`
+
+
+### Override Config Values 
+
+You can easily override default config values by adding them to the `override` option in `config/setting.php`, thereby eliminating the need to modify the default config files and also allowing you to change said values during production. Ex :
+```php
+'override' => [
+        "app.name" => "app_name",
+        "app.env" => "app_env",
+        "mail.driver" => "app_mail_driver",
+        "mail.host" => "app_mail_host",
+],
+```
+The values on the left corresponds to the respective config value (Ex: config('app.name')) and the value on the right is the name of the `key` in your settings table/json file.
+
 
 ### Auto-saving
 

--- a/src/JsonSettingStore.php
+++ b/src/JsonSettingStore.php
@@ -72,6 +72,8 @@ class JsonSettingStore extends SettingStore
 			$contents = '{}';
 		}
 
-		$this->files->put($this->path, $contents);
+		if($data !== $this->read()){
+			$this->files->put($this->path, $contents);
+		}
 	}
 }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -10,6 +10,7 @@
 namespace anlutro\LaravelSettings;
 
 use Illuminate\Foundation\Application;
+use Blade;
 
 class ServiceProvider extends \Illuminate\Support\ServiceProvider
 {
@@ -67,6 +68,25 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
 			$this->publishes([
 				__DIR__.'/migrations/2015_08_25_172600_create_settings_table.php' => database_path('migrations/'.date('Y_m_d_His').'_create_settings_table.php')
 			], 'migrations');
+
+			//Override configs
+			$override = config('settings.override', []);
+
+			foreach (custom_array_dot($override) as $config_key => $setting_key) {
+				$config_key = $config_key ?: $setting_key;
+				try {
+					if (! is_null($value = setting($setting_key))) {
+						config([$config_key => $value]);
+					}
+				} catch (\Exception $e) {
+					continue;
+				}
+			}
+
+			// Register blade directive
+			Blade::directive('setting', function ($expression) {
+				return "<?php echo setting($expression); ?>";
+			});
 		} else {
 			$this->app['config']->package(
 				'anlutro/l4-settings', __DIR__ . '/config', 'anlutro/l4-settings'

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -10,6 +10,7 @@
 namespace anlutro\LaravelSettings;
 
 use Illuminate\Foundation\Application;
+use Illuminate\Support\Arr;
 use Blade;
 
 class ServiceProvider extends \Illuminate\Support\ServiceProvider
@@ -76,7 +77,7 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
 			if(function_exists('array_dot')){
 				$override_values = array_dot($override);
 			}else{
-				$override_values = \Illuminate\Support\Arr::dot($override);
+				$override_values = Arr::dot($override);
 			}
 
 			foreach ($override_values as $config_key => $setting_key) {

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -71,8 +71,11 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
 
 			//Override configs
 			$override = config('settings.override', []);
+			
+			//Compatibility with Laravel >= 5.8 and < 5.7
+			$override_values = function_exists('array_dot')?array_dot($override):\Illuminate\Support\Arr::dot($override);
 
-			foreach (custom_array_dot($override) as $config_key => $setting_key) {
+			foreach ($override_values as $config_key => $setting_key) {
 				$config_key = $config_key ?: $setting_key;
 				try {
 					if (! is_null($value = setting($setting_key))) {

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -73,7 +73,11 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
 			$override = config('settings.override', []);
 			
 			//Compatibility with Laravel >= 5.8 and < 5.7
-			$override_values = function_exists('array_dot')?array_dot($override):\Illuminate\Support\Arr::dot($override);
+			if(function_exists('array_dot')){
+				$override_values = array_dot($override);
+			}else{
+				$override_values = \Illuminate\Support\Arr::dot($override);
+			}
 
 			foreach ($override_values as $config_key => $setting_key) {
 				$config_key = $config_key ?: $setting_key;

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -59,5 +59,19 @@ return [
     */
     'defaults' => [
         'foo' => 'bar',
-    ]
+	],
+
+	/*
+    |--------------------------------------------------------------------------
+    | Override application config values
+    |--------------------------------------------------------------------------
+    |
+    | If defined, settings package will override these config values.
+    |
+    | Sample:
+    |   "app.locale" => "settings.locale",
+    |
+    */
+    'override' => [
+    ],
 ];

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -14,14 +14,3 @@ if (! function_exists('setting')) {
         return $setting;
     }
 }
-
-/*
-* Compatibility with Laravel >= 5.8 and < 5.7
-*/
-if (! function_exists('custom_array_dot')) {
-    function custom_array_dot($array)
-	{
-		//Laravel <= 5.7
-		return  function_exists('array_dot')?array_dot($array):\Illuminate\Support\Arr::dot($array);
-	}
-}

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -14,3 +14,14 @@ if (! function_exists('setting')) {
         return $setting;
     }
 }
+
+/*
+* Compatibility with Laravel >= 5.8 and < 5.7
+*/
+if (! function_exists('custom_array_dot')) {
+    function custom_array_dot($array)
+	{
+		//Laravel <= 5.7
+		return  function_exists('array_dot')?array_dot($array):\Illuminate\Support\Arr::dot($array);
+	}
+}


### PR DESCRIPTION
1. Override configs  and Blade directive imported from `akaunting/setting`
2. Added Laravel <= 5.7 and >= 5.8 compatibility
3. Avoids rewriting the json file when there is equal data