### PR TITLE
Reset and reload data after changing path

### DIFF
--- a/src/JsonSettingStore.php
+++ b/src/JsonSettingStore.php
@@ -43,6 +43,10 @@ class JsonSettingStore extends SettingStore
 		}
 
 		$this->path = $path;
+		
+		// Reset and reload data with new path
+        	$this->forgetAll();
+		$this->load(true);
 	}
 
 	/**


### PR DESCRIPTION
After changing path of .json, reload data.

When a new path is set, then would be better to reload all `$this->data` so that can be used multiple json files as requested here https://github.com/anlutro/laravel-settings/issues/109

So we can do like this:

```php

       //setting()->forgetAll(); // Not required with this pull request
        setting()->setPath(storage_path().'/settings.json');
        //setting()->load(true); // Not required with this pull request
        setting(['settings' => [
            'settings-1' => 'settings-1-val1',
            'settings-2' => 'settings-2-val2',
        ]])->save();

        //setting()->forgetAll(); // Not required with this pull request
        setting()->setPath(storage_path().'/settings2.json');
        //setting()->load(true); // Not required with this pull request
        setting(['settings2' => [
            'settings2-1' => 'settings2-1-val1',
            'settings2-2' => 'settings2-2-val2',
        ]])->save();

        echo '<pre>';

        //setting()->forgetAll(); // Not required with this pull request
        setting()->setPath(storage_path().'/settings.json');
        //setting()->load(true); // Not required with this pull request
        var_dump(setting()->all());

        //setting()->forgetAll(); // Not required with this pull request
        setting()->setPath(storage_path().'/settings2.json');
        //setting()->load(true); // Not required with this pull request
        var_dump(setting()->all());

```

Var dump results:
```

array(1) {
  ["settings"]=>
  array(2) {
    ["settings-1"]=>
    string(9) "settings-1-val1"
    ["settings-2"]=>
    string(9) "settings-2-val2"
  }
}

array(1) {
  ["settings2"]=>
  array(2) {
    ["settings2-1"]=>
    string(9) "settings2-1-val1"
    ["settings2-2"]=>
    string(9) "settings2-2-val2"
  }
}

```