### PR TITLE
Updated ServiceProvider in conformity with Laravel 5.8

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -10,16 +10,10 @@
 namespace anlutro\LaravelSettings;
 
 use Illuminate\Foundation\Application;
+use Illuminate\Contracts\Support\DeferrableProvider;
 
-class ServiceProvider extends \Illuminate\Support\ServiceProvider
+class ServiceProvider extends \Illuminate\Support\ServiceProvider implements DeferrableProvider
 {
-	/**
-	 * This provider is deferred and should be lazy loaded.
-	 *
-	 * @var boolean
-	 */
-	protected $defer = true;
-
 	/**
 	 * Register IoC bindings.
 	 */


### PR DESCRIPTION
[Laravel 5.8 upgrade plan](https://laravel.com/docs/5.8/upgrade#deferred-service-providers)
This fix restores correct work of plugin and moves registering of laravel-settings from eager service list" to defer as it was originally conceived.