### PR TITLE
enable/disable use loaded data

### DIFF
--- a/src/SettingStore.php
+++ b/src/SettingStore.php
@@ -158,7 +158,7 @@ abstract class SettingStore
 	 */
 	public function load($force = false)
 	{
-		if (!$this->loaded || $force) {
+		if ((!($this->loaded && Config::get('settings.enableUseLoadedData'))) || $force) {
 			$this->data = $this->readData();
 			$this->loaded = true;
 		}

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -43,6 +43,8 @@ return [
 	'enableCache' => false,
 	'forgetCacheByWrite' => true,
 	'cacheTtl' => 15,
+	// Use loaded data.
+	'enableUseLoadedData' => true,
 	// If you want to use custom column names in database store you could
 	// set them in this configuration
 	'keyColumn' => 'key',

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -39,6 +39,7 @@ return [
 	// Name of the table used.
 	'table' => 'settings',
 	// Cache usage configurations.
+	// This cache is used when reading from storage, for to reduce storage load.
 	'enableCache' => false,
 	'forgetCacheByWrite' => true,
 	'cacheTtl' => 15,

--- a/tests/functional/AbstractFunctionalTest.php
+++ b/tests/functional/AbstractFunctionalTest.php
@@ -12,6 +12,9 @@ abstract class AbstractFunctionalTest extends PHPUnit_Framework_TestCase
 		Config::shouldReceive('get')
 			->with('settings.enableCache')
 			->andReturn(false)
+			->shouldReceive('get')
+			->with('settings.enableUseLoadedData')
+			->andReturn(true)
 			->getMock();
 	}
 


### PR DESCRIPTION
Hello.

I have problem. I run command:
```
php artisan queue:work
```
I have workers who work very long. They read from a property that is in PHP memory.
```
	protected $data = array();
```
But the settings have already been updated. I want to be able to not use loaded data.
