### PR TITLE
fix behavior of Settings::get when $key is an array and defaults are set

### DIFF
--- a/src/ArrayUtil.php
+++ b/src/ArrayUtil.php
@@ -61,7 +61,12 @@ class ArrayUtil
 		$output = array();
 
 		foreach ($keys as $key) {
-			static::set($output, $key, static::get($input, $key, $default));
+			if ($default) {
+				$keyDefault = static::get($default, $key);
+			} else {
+				$keyDefault = null;
+			}
+			static::set($output, $key, static::get($input, $key, $keyDefault));
 		}
 
 		return $output;

--- a/src/SettingStore.php
+++ b/src/SettingStore.php
@@ -114,8 +114,10 @@ abstract class SettingStore
 	 */
 	public function get($key, $default = null)
 	{
-		if ($default === NULL && !is_array($key)) {
+		if ($default === NULL) {
 			$default = ArrayUtil::get($this->defaults, $key);
+		} elseif (is_array($key) && is_array($default)) {
+			$default = array_merge(ArrayUtil::get($this->defaults, $key, []), $default);
 		}
         
 		$this->load();

--- a/tests/functional/AbstractFunctionalTest.php
+++ b/tests/functional/AbstractFunctionalTest.php
@@ -7,18 +7,30 @@ use Mockery as m;
 
 abstract class AbstractFunctionalTest extends TestCase
 {
-	protected abstract function createStore(array $data = array());
+	protected $defaults;
+
+	protected abstract function createStore(array $data = null);
+
+	protected function getStore(array $data = null)
+	{
+		$store = $this->createStore($data);
+		if ($this->defaults) {
+			$store->setDefaults($this->defaults);
+		}
+		return $store;
+	}
 
 	public function tearDown(): void
 	{
 		m::close();
+		$this->defaults = [];
 	}
 
 	protected function assertStoreEquals($store, $expected, $message = '')
 	{
 		$this->assertEquals($expected, $store->all(), $message);
 		$store->save();
-		$store = $this->createStore();
+		$store = $this->getStore();
 		$this->assertEquals($expected, $store->all(), $message);
 	}
 
@@ -26,21 +38,21 @@ abstract class AbstractFunctionalTest extends TestCase
 	{
 		$this->assertEquals($expected, $store->get($key), $message);
 		$store->save();
-		$store = $this->createStore();
+		$store = $this->getStore();
 		$this->assertEquals($expected, $store->get($key), $message);
 	}
 
 	/** @test */
 	public function store_is_initially_empty()
 	{
-		$store = $this->createStore();
+		$store = $this->getStore();
 		$this->assertEquals(array(), $store->all());
 	}
 
 	/** @test */
 	public function written_changes_are_saved()
 	{
-		$store = $this->createStore();
+		$store = $this->getStore();
 		$store->set('foo', 'bar');
 		$this->assertStoreKeyEquals($store, 'foo', 'bar');
 	}
@@ -48,7 +60,7 @@ abstract class AbstractFunctionalTest extends TestCase
 	/** @test */
 	public function nested_keys_are_nested()
 	{
-		$store = $this->createStore();
+		$store = $this->getStore();
 		$store->set('foo.bar', 'baz');
 		$this->assertStoreEquals($store, array('foo' => array('bar' => 'baz')));
 	}
@@ -56,7 +68,7 @@ abstract class AbstractFunctionalTest extends TestCase
 	/** @test */
 	public function cannot_set_nested_key_on_non_array_member()
 	{
-		$store = $this->createStore();
+		$store = $this->getStore();
 		$store->set('foo', 'bar');
 		$this->expectException('UnexpectedValueException');
 		$this->expectExceptionMessage('Non-array segment encountered');
@@ -66,7 +78,7 @@ abstract class AbstractFunctionalTest extends TestCase
 	/** @test */
 	public function can_forget_key()
 	{
-		$store = $this->createStore();
+		$store = $this->getStore();
 		$store->set('foo', 'bar');
 		$store->set('bar', 'baz');
 		$this->assertStoreEquals($store, array('foo' => 'bar', 'bar' => 'baz'));
@@ -78,7 +90,7 @@ abstract class AbstractFunctionalTest extends TestCase
 	/** @test */
 	public function can_forget_nested_key()
 	{
-		$store = $this->createStore();
+		$store = $this->getStore();
 		$store->set('foo.bar', 'baz');
 		$store->set('foo.baz', 'bar');
 		$store->set('bar.foo', 'baz');
@@ -119,9 +131,18 @@ abstract class AbstractFunctionalTest extends TestCase
 	/** @test */
 	public function can_forget_all()
 	{
-		$store = $this->createStore(array('foo' => 'bar'));
+		$store = $this->getStore(array('foo' => 'bar'));
 		$this->assertStoreEquals($store, array('foo' => 'bar'));
 		$store->forgetAll();
 		$this->assertStoreEquals($store, array());
+	}
+
+	/** @test */
+	public function defaults_are_respected()
+	{
+		$this->defaults = ['foo' => 'default', 'bar' => 'default'];
+		$store = $this->getStore(array('foo' => 'bar'));
+		$this->assertStoreEquals($store, ['foo' => 'bar']);
+		$this->assertStoreKeyEquals($store, ['foo', 'bar'], ['foo' => 'bar', 'bar' => 'default']);
 	}
 }

--- a/tests/functional/DatabaseTest.php
+++ b/tests/functional/DatabaseTest.php
@@ -29,7 +29,7 @@ class DatabaseTest extends AbstractFunctionalTest
 		parent::tearDown();
 	}
 
-	protected function createStore(array $data = array())
+	protected function createStore(array $data = null)
 	{
 		if ($data) {
 			$store = $this->createStore();

--- a/tests/unit/ArrayUtilTest.php
+++ b/tests/unit/ArrayUtilTest.php
@@ -17,6 +17,7 @@ class ArrayUtilTest extends TestCase
 	public function getGetData()
 	{
 		return array(
+			// $data, $key, $expected
 			array(array(), 'foo', null),
 			array(array('foo' => 'bar'), 'foo', 'bar'),
 			array(array('foo' => 'bar'), 'bar', null),
@@ -45,6 +46,26 @@ class ArrayUtilTest extends TestCase
 				array('foo' => array('bar' => 'baz'), 'baz' => null),
 			),
 		);
+	}
+
+	/**
+	 * @test
+	 * @dataProvider getGetWithDefaultsData
+	 */
+	public function getWithDefaultsReturnsCorrectValue(array $data, $key, $default, $expected)
+	{
+		$this->assertEquals($expected, ArrayUtil::get($data, $key, $default));
+	}
+
+	public function getGetWithDefaultsData()
+	{
+		return [
+			// $data, $key, $default, $expected
+			[[], 'foo', 'default', 'default'],
+			[['foo' => 'value'], 'foo', 'default', 'value'],
+			[[], ['foo'], ['foo' => 'default'], ['foo' => 'default']],
+			[['foo' => 'value'], ['foo'], ['foo' => 'default'], ['foo' => 'value']],
+		];
 	}
 
 	/**


### PR DESCRIPTION
`ArrayUtil::get` didn't properly process defaults at all when working with arrays. This meant that `SettingStore::get([...])` also didn't work properly if defaults were set.

Also changed `SettingStore` to properly handle the case of array keys and defaults.

Fixes #143