### PR TITLE
Adding Facade in the standard way for easy instantiation

### DIFF
--- a/src/Facades/Setting.php
+++ b/src/Facades/Setting.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Laravel 4 - Persistent Settings
+ *
+ * @author   Andreas Lutro <anlutro@gmail.com>
+ * @license  http://opensource.org/licenses/MIT
+ * @package  l4-settings
+ */
+
+namespace anlutro\LaravelSettings\Facades;
+
+use \Illuminate\Support\Facades\Facade;
+
+class Setting extends Facade
+{
+    protected static function getFacadeAccessor()
+    {
+        return 'anlutro\LaravelSettings\SettingsManager';
+    }
+}


### PR DESCRIPTION
I use this package in almost every of my projects. But one thing that annoys me every time is that the Facade  of this package is called anlutro\LaravelSettings\Facade so tu use it i must do:

`use anlutro\LaravelSettings\Facade as Setting;`

It's hard to auto-import it with IDEs like PHPStorm.

So this PR creates a new Facade in the standard way like almost every other Laravel Package. So the Facade is now called Setting.php and is located in the Facades folder. So to use it, we just need to do:

`use anlutro\LaravelSettings\Facades\Setting;`

This way PHPStorm and other IDEs can autocomplete the call to Setting and auto-import it's namespace.

I didn't touch the old Facade.php file, for backwards compatibility.