### PR TITLE
Fix dependencies for Laravel 9.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,8 @@
         }
     ],
     "require": {
-        "illuminate/support": ">=4.2 <=9.0",
-        "illuminate/cache": ">=4.2 <=9.0"
+        "illuminate/support": "^4.2|^5|^6|^7|^8|^9",
+        "illuminate/cache": "^4.2|^5|^6|^7|^8|^9"
     },
     "suggest": {
         "illuminate/filesystem": "Save settings to a JSON file.",


### PR DESCRIPTION
Using the Caret Version Range of composer we allow all upcoming versions of Laravel 9.