### PR TITLE
Fix incorrect retrieval of keys anlutro/laravel-settings#165

### DIFF
--- a/src/SettingStore.php
+++ b/src/SettingStore.php
@@ -231,7 +231,7 @@ abstract class SettingStore
 		if (!$this->loaded || $force) {
 			$this->data = $this->readData();
             $this->persistedData = $this->data;
-            $this->data = array_merge($this->updatedData, $this->data);
+            $this->data = $this->updatedData + $this->data;
             $this->loaded = true;
 		}
 	}

--- a/tests/functional/AbstractFunctionalTest.php
+++ b/tests/functional/AbstractFunctionalTest.php
@@ -145,4 +145,15 @@ abstract class AbstractFunctionalTest extends TestCase
 		$this->assertStoreEquals($store, ['foo' => 'bar']);
 		$this->assertStoreKeyEquals($store, ['foo', 'bar'], ['foo' => 'bar', 'bar' => 'default']);
 	}
+
+    /** @test */
+    public function numeric_keys_are_retrieved_correctly()
+    {
+        $store = $this->getStore();
+        $store->set('1234', 'foo');
+        $store->set('9876', 'bar');
+        $store->load(true);
+        $this->assertStoreEquals($store, ['1234' => 'foo', '9876' => 'bar']);
+        $this->assertStoreKeyEquals($store, ['1234', '9876'], ['1234' => 'foo', '9876' => 'bar']);
+    }
 }


### PR DESCRIPTION
Fix retrieval of incorrect keys when numeric keys are stored and fetched using `SettingsStore::all()`. Usage of `array_merge` in `SettingsStore::load()` causes the numeric keys in the resultant array to be renumbered. Using `+` operator to merge two arrays with numeric keys should be a safer option.

Tests:
```
Testing started at 4:53 pm ...
PHPUnit 8.5.30 #StandWithUkraine



Time: 164 ms, Memory: 10.00 MB

OK (65 tests, 117 assertions)
Process finished with exit code 0
```
