### PR TITLE
JsonSettingStore: declare properties used dynamically

### DIFF
--- a/src/JsonSettingStore.php
+++ b/src/JsonSettingStore.php
@@ -13,6 +13,12 @@ use Illuminate\Filesystem\Filesystem;
 
 class JsonSettingStore extends SettingStore
 {
+	/** \Illuminate\Filesystem\Filesystem */
+	public $files;
+
+	/** string Path to settings file. */
+	public $path;
+
 	/**
 	 * @param \Illuminate\Filesystem\Filesystem $files
 	 * @param string                           $path


### PR DESCRIPTION
To avoid PHP 8.2 deprecation notes like:
```
DEPRECATED  Creation of dynamic property anlutro\LaravelSettings\JsonSettingStore::$files is deprecated in vendor/anlutro/l4-settings/src/JsonSettingStore.php on line 22.

DEPRECATED  Creation of dynamic property anlutro\LaravelSettings\JsonSettingStore::$path is deprecated in vendor/anlutro/l4-settings/src/JsonSettingStore.php on line 45.
```

Why public: is properties not declared, they are public by default. I didn't want to introduce a BC break.

___
**Why it's important**: such warnings create a lot of noise in logs